### PR TITLE
Compile with parameter names and change declaration order of aliases

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -183,6 +183,9 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/Core/src/main/java/com/intellectualsites/hyperverse/commands/HyperCommandManager.java
+++ b/Core/src/main/java/com/intellectualsites/hyperverse/commands/HyperCommandManager.java
@@ -66,7 +66,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-@CommandAlias("worlds|world|hyperverse|hv")
+@CommandAlias("hyperverse|hv|worlds|world")
 @CommandPermission("hyperverse.worlds")
 @SuppressWarnings("unused")
 public class HyperCommandManager extends BaseCommand {


### PR DESCRIPTION
Compiling with parameter names will make the usage messages more helpful and `hyperverse` will be shown in the help texts instead of `worlds`