### PR TITLE
Only throw exception if bukkitWorld is really changed afterwards

### DIFF
--- a/Core/src/main/java/se/hyperver/hyperverse/world/SimpleWorld.java
+++ b/Core/src/main/java/se/hyperver/hyperverse/world/SimpleWorld.java
@@ -116,10 +116,13 @@ public class SimpleWorld implements HyperWorld {
     }
 
     @Override public void setBukkitWorld(@NotNull final World world) {
+        if (world.equals(this.bukkitWorld)) { // implicit null check
+            return;
+        }
         if (this.bukkitWorld != null) {
             throw new IllegalStateException("Cannot replace bukkit world");
         }
-        this.bukkitWorld = Objects.requireNonNull(world);
+        this.bukkitWorld = world;
     }
 
     @Override public void saveConfiguration() {


### PR DESCRIPTION
Previously, an exception was thrown when trying to import as the currently loaded world was tried to replace. That's not necessary as it's even the same world reference.